### PR TITLE
12.0.0 GC model update

### DIFF
--- a/model-desc/cds-model.yml
+++ b/model-desc/cds-model.yml
@@ -626,6 +626,7 @@ Relationships:
       - Src: image
         Dst: file
         Mul: one_to_one
+        Req: true
       - Src: proteomic
         Dst: file
       - Src: Protocol
@@ -633,6 +634,7 @@ Relationships:
   of_image:
     Props: null
     Mul: one_to_one
+    Req: true
     Ends:
       - Src: MultiplexMicroscopy
         Dst: image

--- a/model-desc/cds-model.yml
+++ b/model-desc/cds-model.yml
@@ -544,19 +544,25 @@ Relationships:
     Ends:
       - Src: participant
         Dst: study
+        Req: true
       - Src: file
         Dst: study
+        Req: true
       - Src: pdx
         Dst: study
+        Req: true
       - Src: consent_group
         Dst: study
         Mul: many_to_many
+        Req: true
       - Src: investigator
         Dst: study
+        Req: true
       - Src: sample
         Dst: study
       - Src: Protocol
         Dst: study
+        Req: true
   of_consent_group:
     Props: null
     Mul: many_to_one

--- a/model-desc/version-history.md
+++ b/model-desc/version-history.md
@@ -12,6 +12,14 @@
 - Updated the CDE version of the porp: "**_nominal\_magnification_**" to "**_2.00_**".
 - Updated the CDE version of the porp: "**_lens\_numerical\_aperture_**" to "**_2.00_**".
 - Updated the CDE version of the porp: "**_adult\_or\_childhood\_study_**" to "**_3.00_**".
+- Updated the relationship "file-(:of\_study)->study" to be required.
+- Updated the relationship "participant-(:of\_study)->study" to be required.
+- Updated the relationship "pdx-(:of\_study)->study" to be required.
+- Updated the relationship "consent\_group-(:of\_study)->study" to be required.
+- Updated the relationship "investigator-(:of\_study)->study" to be required.
+- Updated the relationship "Protocol-(:of\_study)->study" to be required.
+- Updated the relationship "image-(:of\_file)->file" to be required.
+- Updated all the relationships with the node: "**_image_**" as the direct parent to be required.
 
 ### 11.0.4 (Released 2/18/2026)
 - Renamed the prop: "**_Characterization\_Assay\_Type_**" to the prop: "**_Characterization\_Type_**". The name was changed because it was recommended by the caNano Data SME


### PR DESCRIPTION
Updated the relationship "file-(:of_study)->study" to be required.
Updated the relationship "participant-(:of_study)->study" to be required.
Updated the relationship "pdx-(:of_study)->study" to be required.
Updated the relationship "consent_group-(:of_study)->study" to be required.
Updated the relationship "investigator-(:of_study)->study" to be required.
Updated the relationship "Protocol-(:of_study)->study" to be required.
Updated the relationship "image-(:of_file)->file" to be required.
Updated all the relationships with the node: "image" as the direct parent to be required.